### PR TITLE
Add Projects for Deploying OpenStack

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Official Documentation can be found [here](https://docs.openstack.org/openstack-
 ## Books:
 ### OReilly Publication:
 * [Deploying OpenStack](http://shop.oreilly.com/product/0636920021674.do) by [Ken Pepple](https://twitter.com/ken_pepple)
-* [OpenStack Swift](http://shop.oreilly.com/product/0636920033288.do) by [Joe Arnold](https://twitter.com/joearnold)
+* [OpenStack Swift](https://www.safaribooksonline.com/library/view/openstack-swift/9781491903841/) by [Joe Arnold](https://twitter.com/joearnold)
 * [OpenStack Operations Guide](http://shop.oreilly.com/product/0636920032625.do) by [Tom Fifield, Diane Fleming, Anne Gentle, Lorin Hochstein, Jonathan Proulx, Everett Toews, Joe Topjian](http://shop.oreilly.com/product/0636920032625.do#tab_03_2)
 
 ### Manning Publication:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ _Source:_ [What is Openstack](https://en.wikipedia.org/wiki/OpenStack)
  * [Heat](#heat)
  * [Sahara](#sahara)
  * [Zaqar](#zaqar)
- * [Fuel](#fuel)
+ * [Kolla](#kolla)
+ * [OpenStack-Helm](#openstack-helm)
 * [Books](#books)
  * [OReilly Publication](#oreilly-publication)
  * [Manning Publication](#manning-publication)
@@ -111,6 +112,20 @@ Official Documentation can be found [here](https://docs.openstack.org/sahara/lat
 ## Zaqar:
 Official Documentation can be found [here](https://docs.openstack.org/zaqar/latest/)
 
+## Kolla:
+### Kolla:
+Official Documentation can be found [here](https://docs.openstack.org/kolla/latest/)
+
+### Kolla-Ansible
+Official Documentation can be found [here](https://docs.openstack.org/kolla-ansible/latest/)
+
+### Kolla-Kubernetes
+Official Documentation can be found [here](https://docs.openstack.org/kolla-kubernetes/latest/)
+
+## OpenStack-Helm
+Official Documentation can be found [here](https://docs.openstack.org/openstack-helm/latest/)
+
+* [OpenStack Helm Workshop - OpenStack Summit Sydney](https://github.com/portdirect/sydney-workshop)
 ## Books:
 ### OReilly Publication:
 * [Deploying OpenStack](http://shop.oreilly.com/product/0636920021674.do) by [Ken Pepple](https://twitter.com/ken_pepple)


### PR DESCRIPTION
Added some reference to popular projects to deploy openstack,
including Kolla, Kolla-Ansible, Kolla-Kubernetes, and
OpenStack-Helm. Links to Fuel is also removed.